### PR TITLE
Fixed missing return type that caused a fatal PHP error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 install:
   - composer install

--- a/src/SensitiveDataManager.php
+++ b/src/SensitiveDataManager.php
@@ -34,7 +34,7 @@ class SensitiveDataManager implements EventListener
         $this->sensitiveDataProcessors[] = $sensitiveDataProcessor;
     }
 
-    public function handle(DomainMessage $domainMessage)
+    public function handle(DomainMessage $domainMessage): void
     {
         foreach ($this->sensitiveDataProcessors as $processor) {
             $processor->handle($domainMessage, $this->sensitiveData);


### PR DESCRIPTION
Running the unit tests resulted in `PHP Fatal error:  Declaration of Broadway\BroadwaySensitiveData\EventHandling\SensitiveDataManager::handle(Broadway\Domain\DomainMessage $domainMessage) must be compatible with Broadway\EventHandling\EventListener::handle(Broadway\Domain\DomainMessage $domainMessage): void`

This pull request fixes that.